### PR TITLE
Adds typewriter support to subtitles

### DIFF
--- a/demo/ReplicatedStorage/Data/Audio.lua
+++ b/demo/ReplicatedStorage/Data/Audio.lua
@@ -19,6 +19,7 @@ return {
                         Message = "Attention: Service personnal, please clear helicopter hangar 1.",
                         Speaker = "ASAS",
                         Level = "Dialog",
+                        TypeWriter = true,
                     },
                 },
             },

--- a/demo/ReplicatedStorage/Data/Subtitles.lua
+++ b/demo/ReplicatedStorage/Data/Subtitles.lua
@@ -28,6 +28,7 @@ return {
             Message = "*Announcement chime*",
             MessageColor = Color3.fromRGB(0, 170, 255),
             Level = "ExtraAnnouncement",
+            TypeWriter = true,
         },
         WarningAnnouncement = {
             MessageColor = Color3.fromRGB(255, 170, 0),

--- a/src/EventTransform.lua
+++ b/src/EventTransform.lua
@@ -141,6 +141,7 @@ function EventTransform:Transform(Entries: {Types.SubtitleData}, AudioDuration: 
             Duration = Duration,
             Message = Message,
             Level = Level,
+            TypeWriter = Entry.TypeWriter or false
         })
     end
 

--- a/src/EventTransform.lua
+++ b/src/EventTransform.lua
@@ -141,7 +141,7 @@ function EventTransform:Transform(Entries: {Types.SubtitleData}, AudioDuration: 
             Duration = Duration,
             Message = Message,
             Level = Level,
-            TypeWriter = Entry.TypeWriter or false
+            TypeWriter = Entry.TypeWriter or false,
         })
     end
 

--- a/src/LocalAudioSubtitlesTypes.lua
+++ b/src/LocalAudioSubtitlesTypes.lua
@@ -16,6 +16,7 @@ export type SubtitleData = {
     SpeakerColor: Color3?,
     Level: string | number?,
     Macro: string?,
+    TypeWriter: boolean?,
 }
 
 export type SubtitleSpeaker = {

--- a/src/LocalAudioSubtitlesTypes.lua
+++ b/src/LocalAudioSubtitlesTypes.lua
@@ -38,7 +38,7 @@ export type SubtitleWindow = {
     SubtitleEntries: {SubtitleEntry},
     RowAdornFrame: Frame,
     UpdateSize: (SubtitleWindow) -> (),
-    ShowSubtitle: (SubtitleWindow, Message: string, Duration: number,TypeWriterEnabled: boolean, ReferenceSound: Sound?) -> (),
+    ShowSubtitle: (SubtitleWindow, Message: string, Duration: number, TypeWriterEnabled: boolean, ReferenceSound: Sound?) -> (),
 }
 
 export type SubtitleEntry = {

--- a/src/LocalAudioSubtitlesTypes.lua
+++ b/src/LocalAudioSubtitlesTypes.lua
@@ -38,11 +38,11 @@ export type SubtitleWindow = {
     SubtitleEntries: {SubtitleEntry},
     RowAdornFrame: Frame,
     UpdateSize: (SubtitleWindow) -> (),
-    ShowSubtitle: (SubtitleWindow, Message: string, Duration: number, ReferenceSound: Sound?) -> (),
+    ShowSubtitle: (SubtitleWindow, Message: string, Duration: number,TypeWriterEnabled: boolean, ReferenceSound: Sound?) -> (),
 }
 
 export type SubtitleEntry = {
-    new: (Message: string, Window: SubtitleWindow) -> (SubtitleWindow),
+    new: (Message: string, Window: SubtitleWindow, TypeWriterEnabled: boolean, ReferenceSound: Sound?) -> (SubtitleWindow),
     UpdatePosition: (SubtitleEntry) -> (),
     AddMultiple: (SubtitleEntry) -> (),
     RemoveMultiple: (SubtitleEntry) -> (),

--- a/src/UI/SubtitleEntry.lua
+++ b/src/UI/SubtitleEntry.lua
@@ -11,6 +11,7 @@ local RunService = game:GetService("RunService")
 
 local Types = require(script.Parent.Parent:WaitForChild("LocalAudioSubtitlesTypes"))
 local TweenServicePlay = require(script.Parent.Parent:WaitForChild("Util"):WaitForChild("TweenServicePlay"))
+local TypeWriter = require(script.Parent.Parent:WaitForChild("Util"):WaitForChild("TypeWriter"))
 
 local SubtitleEntry = {}
 SubtitleEntry.__index = SubtitleEntry
@@ -20,7 +21,7 @@ SubtitleEntry.__index = SubtitleEntry
 --[[
 Creates a subtitle entry.
 --]]
-function SubtitleEntry.new(Message: string, Window: Types.SubtitleWindow, ReferenceSound: Sound?): Types.SubtitleEntry
+function SubtitleEntry.new(Message: string, Window: Types.SubtitleWindow, TypeWriterEnabled: boolean, ReferenceSound: Sound?): Types.SubtitleEntry
     --Create the object.
     local self = {
         Message = Message,
@@ -30,6 +31,7 @@ function SubtitleEntry.new(Message: string, Window: Types.SubtitleWindow, Refere
         Visible = false,
         PlaybackLoudnessEvents = {},
         LastReferenceSoundAudible = {},
+        TypeWriterEnabled = TypeWriterEnabled
     }
     setmetatable(self, SubtitleEntry)
 
@@ -120,6 +122,9 @@ function SubtitleEntry:UpdateMultipleText(): ()
                 TextTransparency = 0,
             })
             self.Window:UpdateSize()
+            if self.TypeWriterEnabled then
+                TypeWriter(self.TextLabel, Message)
+            end
         else
             TweenServicePlay(self.TextLabel, TweenInfo.new(0.25), {
                 TextTransparency = 1,

--- a/src/UI/SubtitleEntry.lua
+++ b/src/UI/SubtitleEntry.lua
@@ -123,7 +123,7 @@ function SubtitleEntry:UpdateMultipleText(): ()
             })
             self.Window:UpdateSize()
             if self.TypeWriterEnabled then
-                TypeWriter(self.TextLabel, Message)
+                task.spawn(TypeWriter, self.TextLabel, Message)
             end
         else
             TweenServicePlay(self.TextLabel, TweenInfo.new(0.25), {

--- a/src/UI/SubtitleEntry.lua
+++ b/src/UI/SubtitleEntry.lua
@@ -21,7 +21,7 @@ SubtitleEntry.__index = SubtitleEntry
 --[[
 Creates a subtitle entry.
 --]]
-function SubtitleEntry.new(Message: string, Window: Types.SubtitleWindow, TypeWriterEnabled: boolean, ReferenceSound: Sound?): Types.SubtitleEntry
+function SubtitleEntry.new(Message: string, Window: Types.SubtitleWindow, Duration: number, TypeWriterEnabled: boolean, ReferenceSound: Sound?): Types.SubtitleEntry
     --Create the object.
     local self = {
         Message = Message,
@@ -31,7 +31,8 @@ function SubtitleEntry.new(Message: string, Window: Types.SubtitleWindow, TypeWr
         Visible = false,
         PlaybackLoudnessEvents = {},
         LastReferenceSoundAudible = {},
-        TypeWriterEnabled = TypeWriterEnabled
+        TypeWriterEnabled = TypeWriterEnabled,
+        Duration = Duration,
     }
     setmetatable(self, SubtitleEntry)
 
@@ -123,7 +124,7 @@ function SubtitleEntry:UpdateMultipleText(): ()
             })
             self.Window:UpdateSize()
             if self.TypeWriterEnabled then
-                task.spawn(TypeWriter, self.TextLabel, Message)
+                task.spawn(TypeWriter, self.TextLabel, Message, (self.Duration/Message:len()))
             end
         else
             TweenServicePlay(self.TextLabel, TweenInfo.new(0.25), {

--- a/src/UI/SubtitleEntry.lua
+++ b/src/UI/SubtitleEntry.lua
@@ -124,7 +124,7 @@ function SubtitleEntry:UpdateMultipleText(): ()
             })
             self.Window:UpdateSize()
             if self.TypeWriterEnabled then
-                task.spawn(TypeWriter, self.TextLabel, Message, (self.Duration/Message:len()))
+                task.spawn(TypeWriter, self.TextLabel, Message, (self.Duration / string.len(Message)))
             end
         else
             TweenServicePlay(self.TextLabel, TweenInfo.new(0.25), {

--- a/src/UI/SubtitleWindow.lua
+++ b/src/UI/SubtitleWindow.lua
@@ -176,7 +176,7 @@ function SubtitleWindow:ShowSubtitle(Message: string, Duration: number, TypeWrit
 
     --Create the entry.
     if not Entry then
-        Entry = SubtitleEntry.new(Message, self, TypeWriterEnabled, ReferenceSound)
+        Entry = SubtitleEntry.new(Message, self, Duration, TypeWriterEnabled, ReferenceSound)
     end
 
     --Remove the entry after the duration.

--- a/src/UI/SubtitleWindow.lua
+++ b/src/UI/SubtitleWindow.lua
@@ -159,7 +159,7 @@ end
 --[[
 Shows a subtitle in the window.
 --]]
-function SubtitleWindow:ShowSubtitle(Message: string, Duration: number, ReferenceSound: Sound?): ()
+function SubtitleWindow:ShowSubtitle(Message: string, Duration: number, TypeWriterEnabled: boolean, ReferenceSound: Sound?): ()
     --Add to an existing message if one exists.
     local Entry = nil
     for _, ExistingEntry in self.SubtitleEntries do
@@ -176,7 +176,7 @@ function SubtitleWindow:ShowSubtitle(Message: string, Duration: number, Referenc
 
     --Create the entry.
     if not Entry then
-        Entry = SubtitleEntry.new(Message, self, ReferenceSound)
+        Entry = SubtitleEntry.new(Message, self, TypeWriterEnabled, ReferenceSound)
     end
 
     --Remove the entry after the duration.

--- a/src/Util/TypeWriter.lua
+++ b/src/Util/TypeWriter.lua
@@ -1,0 +1,17 @@
+return function(label: TextLabel, text: string, delayBetweenChars: number?)
+	local displayText = text
+
+	-- Replace line break tags so grapheme loop will not miss those characters
+	displayText = displayText:gsub("<br%s*/>", "\n")
+	displayText:gsub("<[^<>]->", "")
+
+	-- Set modified text on parent
+	label.Text = displayText
+
+	local index = 0
+	for _ in utf8.graphemes(displayText) do
+		index = index + 1
+		label.MaxVisibleGraphemes = index
+		task.wait(delayBetweenChars)
+	end
+end

--- a/src/Util/TypeWriter.lua
+++ b/src/Util/TypeWriter.lua
@@ -1,17 +1,17 @@
-return function(label: TextLabel, text: string, delayBetweenChars: number?)
-	local displayText = text
+return function(Label: TextLabel, Text: string, DelayBetweenCharacters: number?)
+	local DisplayText = Text
 
 	-- Replace line break tags so grapheme loop will not miss those characters
-	displayText = displayText:gsub("<br%s*/>", "\n")
-	displayText:gsub("<[^<>]->", "")
+	DisplayText = string.gsub(DisplayText, "<br%s*/>", "\n")
+	DisplayText = string.gsub(DisplayText, "<[^<>]->", "")
 
 	-- Set modified text on parent
-	label.Text = displayText
+	Label.Text = DisplayText
 
 	local index = 0
-	for _ in utf8.graphemes(displayText) do
+	for _ in utf8.graphemes(DisplayText) do
 		index = index + 1
-		label.MaxVisibleGraphemes = index
-		task.wait(delayBetweenChars)
+		Label.MaxVisibleGraphemes = index
+		task.wait(DelayBetweenCharacters)
 	end
 end

--- a/src/init.lua
+++ b/src/init.lua
@@ -42,7 +42,7 @@ function LocalAudioSubtitles:SetUp(LocalAudioModule: ModuleScript, SubtitlesData
 
     --Connect the events.
     require(LocalAudioModule):OnEventFired("ShowSubtitle"):Connect(function(_, SubtitleEvent, Parent: Instance?, Sound: Sound)
-        self:ShowSubtitle(SubtitleEvent.Message, SubtitleEvent.Duration, SubtitleEvent.Level, Parent and Sound or nil)
+        self:ShowSubtitle(SubtitleEvent.Message, SubtitleEvent.Duration, SubtitleEvent.Level, SubtitleEvent.TypeWriter or false, Parent and Sound or nil)
     end)
 end
 


### PR DESCRIPTION
Adds typewriter support to subtitles, suggestion originally came from: [discord](https://discord.com/channels/600633774929215488/916614615029399573/1203586495512977408)

Typewriter is by default off, but can be toggled by enabling it:
![image](https://github.com/IITPP-Roblox/LocalAudio-Subtitles/assets/73340248/ad53d2ed-2cfb-4725-82cf-d456360ed39e)


Changes:

- Added typewriter module
- Added typewriter option
- Typewriter is based on duration and message length